### PR TITLE
Escape backslashes in bundlePath

### DIFF
--- a/sikuli-ide/src/main/java/org/sikuli/ide/sikuli_test/TextUnitTestRunner.java
+++ b/sikuli-ide/src/main/java/org/sikuli/ide/sikuli_test/TextUnitTestRunner.java
@@ -59,7 +59,7 @@ public class TextUnitTestRunner extends junit.textui.TestRunner {
          "\tdef __init__(self, name):\n"+
          "\t\tjunit.framework.TestCase.__init__(self,name)\n"+
          "\t\tself.theTestFunction = getattr(self,name)\n"+
-         "\t\tsetBundlePath('"+bundlePath+"')\n"+
+         "\t\tsetBundlePath('"+bundlePath.replace("\\", "\\\\")+"')\n"+
          "\tdef runTest(self):\n"+
          "\t\tself.theTestFunction()\n";
 


### PR DESCRIPTION
This fixes java -jar sikuli-ide.jar -t test sikuli on Windows when the path contains a Python string escape sequence
