### PR TITLE
Fix documentation URLs

### DIFF
--- a/sikuli-ide/src/main/java/org/sikuli/ide/SikuliIDE.java
+++ b/sikuli-ide/src/main/java/org/sikuli/ide/SikuliIDE.java
@@ -1186,11 +1186,11 @@ public class SikuliIDE extends JFrame {
 
       
       public void openDoc(ActionEvent ae){
-         openURL("http://sikuli.org/documentation.shtml");
+         openURL("http://doc.sikuli.org/");
       }
 
       public void openGuide(ActionEvent ae){
-         openURL("http://sikuli.org/guide-x");
+         openURL("http://doc.sikuli.org/index.html#complete-guide-to-sikuli-script");
       }
 
       public void openAsk(ActionEvent ae){


### PR DESCRIPTION
Something tells me that these should not be hardcoded in the source,
but in some resource file.
